### PR TITLE
Removing manual tar handling.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,15 +10,6 @@ var Generator = module.exports = function() {
     'README.md',
   ];
 
-  this.argument('tarFile');
-  if (this.tarFile) {
-    this.tarball(this.tarFile, process.cwd(), function (err) {
-      if (err) {
-        throw err;
-      }
-    });
-  }
-
   this.package = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));
 
   this.log.writeln('Generating from ' + 'jQuery Boilerplate'.cyan + ' v' + this.package.version.cyan + '...');


### PR DESCRIPTION
Apparently Yeoman handles the TAR stuff on its own.

See [generator-firefox-os/db3bb9f7f904591e9b3b5409adc3fb96c9ecd601](https://github.com/zenorocha/generator-firefox-os/commit/db3bb9f7f904591e9b3b5409adc3fb96c9ecd601).
refs #2
