### PR TITLE
Moving to peerDeps, updating install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 ## Usage
 
-1. Install [Yeoman](https://github.com/yeoman/yo): `npm install -g yo`
-2. Install this generator: `npm install -g generator-jquery-boilerplate`
-3. Run: `yo jquery-boilerplate`
-4. Start writing your jQuery plugin :)
+1. Install the generator by running: `npm install -g generator-jquery-boilerplate`
+2. Run: `yo jquery-boilerplate`
+3. Start writing your jQuery plugin :)
 
 ## Wanna know more?
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,12 @@
 	"scripts": {
 		"test": "mocha --reporter spec"
 	},
+	"peerDependencies": {
+	    "yo": ">=1.0.0-rc.1.1"
+	},
 	"engines": {
-		"node": ">=0.8.0"
+	    "node": ">= 0.8.0",
+	    "npm": ">=1.2.10"
 	},
 	"dependencies": {
 		"yeoman-generator": "~0.10.2"


### PR DESCRIPTION
This change allows users to skip the `yo` install step and just run one line to get the generator and all of its dependencies installed.

Note that once merged, you will need to tag and publish a new release as the older instructions will be out of date.
