### PR TITLE
Upgraded to yeoman-generator 0.12

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var chalk = require('chalk');
 
 var Generator = module.exports = function() {
   var prompts = [];
@@ -12,7 +13,7 @@ var Generator = module.exports = function() {
 
   this.package = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));
 
-  this.log.writeln('Generating from ' + 'jQuery Boilerplate'.cyan + ' v' + this.package.version.cyan + '...');
+  this.log.writeln('Generating from ' + chalk.cyan('jQuery Boilerplate') + ' v' + chalk.cyan(this.package.version) + '...');
 
   files.forEach(function(file) {
     if (ignores.indexOf(file) !== -1) {

--- a/package.json
+++ b/package.json
@@ -20,24 +20,25 @@
 	},
 	"license": [
 		{
-			"type": "MIT",
-			"url": "http://zenorocha.mit-license.org/"
-		}
+		"type": "MIT",
+		"url": "http://zenorocha.mit-license.org/"
+	}
 	],
 	"scripts": {
 		"test": "mocha --reporter spec"
 	},
 	"peerDependencies": {
-	    "yo": ">=1.0.0-rc.1.1"
+		"yo": ">=1.0.0-rc.1.1"
 	},
 	"engines": {
-	    "node": ">= 0.8.0",
-	    "npm": ">=1.2.10"
+		"node": ">= 0.8.0",
+		"npm": ">=1.2.10"
 	},
 	"dependencies": {
-		"yeoman-generator": "~0.10.2"
+		"yeoman-generator": "~0.12.0",
+		"chalk": "~0.2.0"
 	},
 	"devDependencies": {
-		"mocha": "~1.9.0"
+		"mocha": "~1.12.0"
 	}
 }


### PR DESCRIPTION
Migrated to chalk for output coloring. `colors` was assumed to be implicitly
present in the String prototype, which is no longer the case. Also fixed
indentation of the `package.json`.
